### PR TITLE
Add Dapr multi-component integration test

### DIFF
--- a/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
@@ -22,7 +22,10 @@ public class MultiComponentEnvironmentTests(AspireIntegrationTestFixture<Project
             await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(serviceName).WaitAsync(TimeSpan.FromMinutes(5));
 
             var resource = Assert.Single(model.Resources, r => r.Name == serviceName);
-            var env = await ((IResourceWithEnvironment)resource).GetEnvironmentVariableValuesAsync(DistributedApplicationOperation.Run);
+            // Use the default execution context when retrieving environment variables
+            // to avoid accessing the service provider before the application has
+            // finished building.
+            var env = await ((IResourceWithEnvironment)resource).GetEnvironmentVariableValuesAsync();
 
             Assert.Contains("DAPR_HTTP_PORT", env.Keys);
             Assert.Contains("DAPR_GRPC_PORT", env.Keys);

--- a/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
@@ -1,0 +1,32 @@
+using Aspire.Components.Common.Tests;
+using CommunityToolkit.Aspire.Testing;
+using Aspire.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CommunityToolkit.Aspire.Hosting.Dapr.Tests;
+
+[RequiresDocker]
+public class MultiComponentEnvironmentTests(AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_Dapr_AppHost> fixture)
+    : IClassFixture<AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_Dapr_AppHost>>
+{
+    [Fact]
+    public async Task SidecarsExposeEnvironmentVariables()
+    {
+        string[] services = ["servicea", "serviceb", "servicec"];
+
+        var model = fixture.App.Services.GetRequiredService<DistributedApplicationModel>();
+
+        foreach (var serviceName in services)
+        {
+            await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(serviceName).WaitAsync(TimeSpan.FromMinutes(5));
+
+            var resource = Assert.Single(model.Resources, r => r.Name == serviceName);
+            var env = await resource.GetEnvironmentVariableValuesAsync(DistributedApplicationOperation.Run);
+
+            Assert.Contains("DAPR_HTTP_PORT", env.Keys);
+            Assert.Contains("DAPR_GRPC_PORT", env.Keys);
+            Assert.Contains("DAPR_HTTP_ENDPOINT", env.Keys);
+            Assert.Contains("DAPR_GRPC_ENDPOINT", env.Keys);
+        }
+    }
+}

--- a/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
@@ -1,6 +1,7 @@
 using Aspire.Components.Common.Tests;
 using CommunityToolkit.Aspire.Testing;
 using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CommunityToolkit.Aspire.Hosting.Dapr.Tests;
@@ -21,7 +22,7 @@ public class MultiComponentEnvironmentTests(AspireIntegrationTestFixture<Project
             await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(serviceName).WaitAsync(TimeSpan.FromMinutes(5));
 
             var resource = Assert.Single(model.Resources, r => r.Name == serviceName);
-            var env = await resource.GetEnvironmentVariableValuesAsync(DistributedApplicationOperation.Run);
+            var env = await ((IResourceWithEnvironment)resource).GetEnvironmentVariableValuesAsync(DistributedApplicationOperation.Run);
 
             Assert.Contains("DAPR_HTTP_PORT", env.Keys);
             Assert.Contains("DAPR_GRPC_PORT", env.Keys);


### PR DESCRIPTION
## Summary
- add integration test ensuring Dapr environment variables exist when multiple components are used

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*