### PR TITLE
Add Dapr sidecar command line builder

### DIFF
--- a/src/Shared/Dapr/Core/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Shared/Dapr/Core/DaprDistributedApplicationLifecycleHook.cs
@@ -149,35 +149,12 @@ internal sealed class DaprDistributedApplicationLifecycleHook(
 #pragma warning restore CS0618 // Type or member is obsolete
 
             var daprCommandLine =
-                CommandLineBuilder
-                    .Create(
-                        fileName,
-                        Command("run"),
-                        daprAppPortArg(sidecarOptions?.AppPort),
-                        ModelNamedArg("--app-channel-address", sidecarOptions?.AppChannelAddress),
-                        ModelNamedArg("--app-health-check-path", sidecarOptions?.AppHealthCheckPath),
-                        ModelNamedArg("--app-health-probe-interval", sidecarOptions?.AppHealthProbeInterval),
-                        ModelNamedArg("--app-health-probe-timeout", sidecarOptions?.AppHealthProbeTimeout),
-                        ModelNamedArg("--app-health-threshold", sidecarOptions?.AppHealthThreshold),
-                        ModelNamedArg("--app-id", appId),
-                        ModelNamedArg("--app-max-concurrency", sidecarOptions?.AppMaxConcurrency),
-                        ModelNamedArg("--app-protocol", sidecarOptions?.AppProtocol),
-                        ModelNamedArg("--config", NormalizePath(sidecarOptions?.Config)),
-                        ModelNamedArg("--max-body-size", sidecarOptions?.DaprMaxBodySize),
-                        ModelNamedArg("--read-buffer-size", sidecarOptions?.DaprReadBufferSize),
-                        ModelNamedArg("--dapr-internal-grpc-port", sidecarOptions?.DaprInternalGrpcPort),
-                        ModelNamedArg("--dapr-listen-addresses", sidecarOptions?.DaprListenAddresses),
-                        Flag("--enable-api-logging", sidecarOptions?.EnableApiLogging),
-                        Flag("--enable-app-health-check", sidecarOptions?.EnableAppHealthCheck),
-                        Flag("--enable-profiling", sidecarOptions?.EnableProfiling),
-                        ModelNamedArg("--log-level", sidecarOptions?.LogLevel),
-                        ModelNamedArg("--placement-host-address", sidecarOptions?.PlacementHostAddress),
-                        ModelNamedArg("--resources-path", aggregateResourcesPaths),
-                        ModelNamedArg("--run-file", NormalizePath(sidecarOptions?.RunFile)),
-                        ModelNamedArg("--runtime-path", NormalizePath(sidecarOptions?.RuntimePath)),
-                        ModelNamedArg("--scheduler-host-address", sidecarOptions?.SchedulerHostAddress),
-                        ModelNamedArg("--unix-domain-socket", sidecarOptions?.UnixDomainSocket),
-                        PostOptionsArgs(Args(sidecarOptions?.Command)));
+                DaprSidecarCommandLineBuilder.Create(
+                    fileName,
+                    sidecarOptions,
+                    aggregateResourcesPaths,
+                    appId,
+                    NormalizePath);
 
             var daprCliResourceName = $"{daprSidecar.Name}-cli";
             var daprCli = new ExecutableResource(daprCliResourceName, fileName, appHostDirectory);

--- a/src/Shared/Dapr/Core/DaprSidecarCommandLineBuilder.cs
+++ b/src/Shared/Dapr/Core/DaprSidecarCommandLineBuilder.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using static CommunityToolkit.Aspire.Hosting.Dapr.CommandLineArgs;
+
+namespace CommunityToolkit.Aspire.Hosting.Dapr;
+
+internal static class DaprSidecarCommandLineBuilder
+{
+    public static CommandLine Create(
+        string fileName,
+        DaprSidecarOptions? sidecarOptions,
+        IEnumerable<string> aggregateResourcesPaths,
+        string appId,
+        Func<string?, string?> normalizePath)
+    {
+        return CommandLineBuilder.Create(
+            fileName,
+            Command("run"),
+            ModelNamedArg("--app-port", sidecarOptions?.AppPort),
+            ModelNamedArg("--app-channel-address", sidecarOptions?.AppChannelAddress),
+            ModelNamedArg("--app-health-check-path", sidecarOptions?.AppHealthCheckPath),
+            ModelNamedArg("--app-health-probe-interval", sidecarOptions?.AppHealthProbeInterval),
+            ModelNamedArg("--app-health-probe-timeout", sidecarOptions?.AppHealthProbeTimeout),
+            ModelNamedArg("--app-health-threshold", sidecarOptions?.AppHealthThreshold),
+            ModelNamedArg("--app-id", appId),
+            ModelNamedArg("--app-max-concurrency", sidecarOptions?.AppMaxConcurrency),
+            ModelNamedArg("--app-protocol", sidecarOptions?.AppProtocol),
+            ModelNamedArg("--config", normalizePath(sidecarOptions?.Config)),
+            ModelNamedArg("--max-body-size", sidecarOptions?.DaprMaxBodySize),
+            ModelNamedArg("--read-buffer-size", sidecarOptions?.DaprReadBufferSize),
+            ModelNamedArg("--dapr-internal-grpc-port", sidecarOptions?.DaprInternalGrpcPort),
+            ModelNamedArg("--dapr-listen-addresses", sidecarOptions?.DaprListenAddresses),
+            Flag("--enable-api-logging", sidecarOptions?.EnableApiLogging),
+            Flag("--enable-app-health-check", sidecarOptions?.EnableAppHealthCheck),
+            Flag("--enable-profiling", sidecarOptions?.EnableProfiling),
+            ModelNamedArg("--log-level", sidecarOptions?.LogLevel),
+            ModelNamedArg("--placement-host-address", sidecarOptions?.PlacementHostAddress),
+            ModelNamedArg("--resources-path", aggregateResourcesPaths),
+            ModelNamedArg("--run-file", normalizePath(sidecarOptions?.RunFile)),
+            ModelNamedArg("--runtime-path", normalizePath(sidecarOptions?.RuntimePath)),
+            ModelNamedArg("--scheduler-host-address", sidecarOptions?.SchedulerHostAddress),
+            ModelNamedArg("--unix-domain-socket", sidecarOptions?.UnixDomainSocket),
+            PostOptionsArgs(Args(sidecarOptions?.Command)));
+    }
+}

--- a/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/DaprSidecarCommandLineBuilderTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/DaprSidecarCommandLineBuilderTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Collections.Immutable;
+using CommunityToolkit.Aspire.Hosting.Dapr;
+using Xunit;
+
+namespace CommunityToolkit.Aspire.Hosting.Dapr.Tests;
+
+public class DaprSidecarCommandLineBuilderTests
+{
+    [Fact]
+    public void Create_Builds_Expected_Arguments()
+    {
+        var options = new DaprSidecarOptions
+        {
+            AppPort = 5001,
+            EnableApiLogging = true,
+            Command = new[] { "myapp" }.ToImmutableList()
+        };
+
+        var commandLine = DaprSidecarCommandLineBuilder.Create(
+            "dapr",
+            options,
+            new[] { "./resources" },
+            "myapp",
+            p => p);
+
+        var args = string.Join(" ", commandLine.Arguments);
+
+        Assert.Contains("--app-port", args);
+        Assert.Contains("5001", args);
+        Assert.Contains("--enable-api-logging", args);
+        Assert.Contains("--resources-path", args);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize CLI args for Dapr sidecar in `DaprSidecarCommandLineBuilder`
- use new builder in `DaprDistributedApplicationLifecycleHook`
- add unit test for new builder

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not found)*