### PR TITLE
Fix environment variable test for Dapr sidecars

### DIFF
--- a/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/MultiComponentEnvironmentTests.cs
@@ -1,6 +1,7 @@
 using Aspire.Components.Common.Tests;
 using CommunityToolkit.Aspire.Testing;
 using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CommunityToolkit.Aspire.Hosting.Dapr.Tests;
@@ -21,7 +22,7 @@ public class MultiComponentEnvironmentTests(AspireIntegrationTestFixture<Project
             await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(serviceName).WaitAsync(TimeSpan.FromMinutes(5));
 
             var resource = Assert.Single(model.Resources, r => r.Name == serviceName);
-            var env = await resource.GetEnvironmentVariableValuesAsync(DistributedApplicationOperation.Run);
+            var env = await ((IResourceWithEnvironment)resource).GetEnvironmentVariableValuesAsync(DistributedApplicationOperation.Run);
 
             Assert.Contains("DAPR_HTTP_PORT", env.Keys);
             Assert.Contains("DAPR_GRPC_PORT", env.Keys);


### PR DESCRIPTION
## Summary
- ensure MultiComponentEnvironmentTests casts to `IResourceWithEnvironment` before calling `GetEnvironmentVariableValuesAsync`

## Testing
- `dotnet build tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests.csproj` *(fails: `bash: dotnet: command not found`)*